### PR TITLE
Improved Focus Point Selection

### DIFF
--- a/src/main/display/OverviewPanel.java
+++ b/src/main/display/OverviewPanel.java
@@ -29,7 +29,7 @@ public class OverviewPanel extends JPanel{
 	ShapeDrawSpecifications shapeSpecs = new ShapeDrawSpecifications();
 	public OverviewPanel() {
 		super();
-		preview = new PreviewCanvas();
+		preview = new PreviewCanvas(shapeSpecs);
 		this.setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
 		
 		this.add(getLeftSidePanels());
@@ -48,14 +48,14 @@ public class OverviewPanel extends JPanel{
 		
 		leftSide.add(new ShapeColorSelectionPanel(shapeSpecs, preview));
 		leftSide.add(createVerticalPadding(10));
-		
-		leftSide.add(new FocusSelectionPanel(shapeSpecs, preview));
-		leftSide.add(createVerticalPadding(10));
 
 		leftSide.add(new ImageTypePanel(shapeSpecs, preview));
 		leftSide.add(createVerticalPadding(10));
 		
 		leftSide.add(new BackgroundColorSelectionPanel(shapeSpecs, preview));
+		leftSide.add(createVerticalPadding(10));
+
+		leftSide.add(new FocusSelectionPanel(shapeSpecs, preview));
 		leftSide.add(createVerticalPadding(10));
 		
 		leftSide.add(getButtonPanel());

--- a/src/main/display/PreviewCanvas.java
+++ b/src/main/display/PreviewCanvas.java
@@ -5,9 +5,14 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 
 import javax.swing.JPanel;
+
+import main.shapes.ShapeDrawSpecifications;
 
 public class PreviewCanvas extends JPanel{
 	private static final long serialVersionUID = 3297155955034907974L;
@@ -15,9 +20,32 @@ public class PreviewCanvas extends JPanel{
 	BufferedImage shapesToDraw;
 	public Color baseColor = Color.black;
 	Dimension dimensions = new Dimension(600, 600);
-	public PreviewCanvas() {
+	ShapeDrawSpecifications specs;
+	public PreviewCanvas(ShapeDrawSpecifications specs) {
 		super();
+		this.specs = specs;
 		this.setPreferredSize(dimensions);
+		
+		this.addMouseListener(new MouseListener() {
+
+			public void mouseClicked(MouseEvent e) {
+				
+				double xModRatio = specs.imageScale.getWidth() / dimensions.getWidth();
+				double yModRatio = specs.imageScale.getWidth() / dimensions.getWidth();
+				if(e.getPoint().x*xModRatio < specs.imageScale.getWidth() && e.getPoint().y*yModRatio < specs.imageScale.getHeight()) {
+					specs.centerPoint = new Point2D.Double(e.getPoint().x*xModRatio, e.getPoint().y*yModRatio);
+					specs.clearImage();
+					setShapesToDraw(specs.getImage());
+					baseColor = specs.baseColor;
+					repaint();
+				}
+			}
+			public void mousePressed(MouseEvent e) {}
+			public void mouseReleased(MouseEvent e) {}
+			public void mouseEntered(MouseEvent e) {}
+			public void mouseExited(MouseEvent e) {}
+			
+		});
 	}
 	
 	public void setShapesToDraw(BufferedImage shapes) {
@@ -32,6 +60,19 @@ public class PreviewCanvas extends JPanel{
         g2.setStroke(new BasicStroke(2));
         double widthHeightRatio = ((double)shapesToDraw.getHeight())/(double)shapesToDraw.getWidth();
         g2.drawImage(shapesToDraw, 0, 0, (int)dimensions.getWidth(), (int)(dimensions.getHeight()*widthHeightRatio), null);
+
+
+		double xModRatio = dimensions.getWidth() / specs.imageScale.getWidth();
+		double yModRatio = dimensions.getWidth() / specs.imageScale.getWidth() ;
+		Point2D.Double p = new Point2D.Double(specs.centerPoint.x*xModRatio, specs.centerPoint.y*yModRatio);
+        g2.setStroke(new BasicStroke(4));
+        g2.setColor(Color.black);
+        g2.drawLine((int)p.x-8, (int)p.y, (int)p.x+8, (int)p.y);
+        g2.drawLine((int)p.x, (int)p.y-8, (int)p.x, (int)p.y+8);
+        g2.setStroke(new BasicStroke(2));
+        g2.setColor(Color.white);
+        g2.drawLine((int)p.x-7, (int)p.y, (int)p.x+7, (int)p.y);
+        g2.drawLine((int)p.x, (int)p.y-7, (int)p.x, (int)p.y+7);
         g2.dispose();
     }
 }

--- a/src/main/display/leftPanel/FocusSelectionPanel.java
+++ b/src/main/display/leftPanel/FocusSelectionPanel.java
@@ -29,45 +29,8 @@ public class FocusSelectionPanel extends JPanel{
 		
 		JPanel focusSelectLabelContainer = new JPanel(new FlowLayout(FlowLayout.LEFT));
 		focusSelectLabelContainer.setMaximumSize(new Dimension(10000, 50));
-		JLabel focusSelectLabel = new JLabel("Select desired focus Point:");		
+		JLabel focusSelectLabel = new JLabel("Focus can be changed by clicking on the preview to the right.");		
 		focusSelectLabelContainer.add(focusSelectLabel);
 		this.add(focusSelectLabelContainer);
-
-		
-		JPanel focusSelectButtons = new JPanel();
-		ButtonGroup focusSelectGroup = new ButtonGroup();
-		focusSelectButtons.setMaximumSize(new Dimension(10000, 150));
-		this.add(focusSelectButtons);
-		focusSelectButtons.setLayout(new GridLayout(1, 5));	
-		focusSelectButtons.add(createRadioButtonForFocusSelect(true, "Top Left", 1d/6d, 1d/6d, focusSelectGroup));
-		focusSelectButtons.add(createRadioButtonForFocusSelect(false, "Top Right", 5d/6d, 1d/6d, focusSelectGroup));
-		focusSelectButtons.add(createRadioButtonForFocusSelect(false, "Center", .5, .5, focusSelectGroup));
-		focusSelectButtons.add(createRadioButtonForFocusSelect(false, "Bottom Left", 1d/6d, 5d/6d, focusSelectGroup));
-		focusSelectButtons.add(createRadioButtonForFocusSelect(false, "Bottom Right", 5d/6d, 5d/6d, focusSelectGroup));
-		
-	}
-	private JPanel createRadioButtonForFocusSelect(boolean selected, String labelText, double widthMod, double heightMod, ButtonGroup group) {
-		JPanel option = new JPanel();
-		option.setLayout(new FlowLayout(FlowLayout.RIGHT));
-		JLabel label = new JLabel(labelText);
-		option.add(label);
-		option.setAlignmentX(JPanel.RIGHT_ALIGNMENT);
-		JRadioButton radioButton = new JRadioButton();
-		radioButton.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				specs.centerMod = new Point2D.Double(widthMod, heightMod);
-				specs.recalculateFocus();
-				specs.clearImage();
-				preview.setShapesToDraw(specs.getImage());
-				preview.baseColor = specs.baseColor;
-				preview.repaint();
-			}
-			
-		});
-		option.add(radioButton);
-		group.add(radioButton);
-		radioButton.setSelected(selected);
-		return option;
 	}
 }

--- a/src/main/display/leftPanel/ImageTypePanel.java
+++ b/src/main/display/leftPanel/ImageTypePanel.java
@@ -6,6 +6,7 @@ import java.awt.GridLayout;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.geom.Point2D;
 
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
@@ -57,9 +58,10 @@ public class ImageTypePanel extends JPanel{
 		radioButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
+				Dimension oldImageScale = new Dimension((int)specs.imageScale.getWidth(), (int)specs.imageScale.getHeight());
 				specs.imageScale = dimension;
 				specs.baseSize = dimension.height/40;
-				specs.recalculateFocus();
+				specs.centerPoint = new Point2D.Double(specs.centerPoint.x * dimension.getWidth()/oldImageScale.getWidth(), specs.centerPoint.y * dimension.getHeight()/oldImageScale.getHeight());
 				specs.clearImage();
 				preview.setShapesToDraw(specs.getImage());
 				preview.baseColor = specs.baseColor;

--- a/src/main/shapes/ShapeDrawSpecifications.java
+++ b/src/main/shapes/ShapeDrawSpecifications.java
@@ -19,8 +19,7 @@ public class ShapeDrawSpecifications {
 	private double minScaler = .33;
 	public int baseSize = 15; 
 	public Dimension imageScale = new Dimension(600, 600);
-	public Point2D.Double centerMod = new Point2D.Double(1d/6d, 1d/6d);
-	public Point2D.Double centerPoint = new Point2D.Double(imageScale.width*centerMod.x, imageScale.height*centerMod.y);
+	public Point2D.Double centerPoint = new Point2D.Double(imageScale.width/2, imageScale.height/2);
 	private int numGroups = (int)imageScale.getWidth()/baseSize;
 	private int numPerGroup = 5;
 	private int baseTransparency = 9;
@@ -38,10 +37,6 @@ public class ShapeDrawSpecifications {
 				Shape.getRegularPolygon(5, baseSize, centerPoint),
 				Shape.getRegularPolygon(6, baseSize, centerPoint)
 			));
-	}
-	
-	public void recalculateFocus() {
-		centerPoint = new Point2D.Double(imageScale.width*centerMod.x, imageScale.height*centerMod.y);
 	}
 	public void clearBaseShapes() {
 		baseShapes = new ArrayList<>();


### PR DESCRIPTION
Changed focus point selection to now work off of where the user clicks on the preview image. Also provided a visual indicator as to where the current focus was at.

Scales with adjustment to image dimensions.

![image](https://github.com/user-attachments/assets/f54453de-fca9-4657-98d6-c8ef5504c02e)
